### PR TITLE
Some fixes for multi-acceptors and using shared_ptr<>:

### DIFF
--- a/common.h
+++ b/common.h
@@ -12,6 +12,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 #include <boost/algorithm/string.hpp>

--- a/test-otpc-conn.cpp
+++ b/test-otpc-conn.cpp
@@ -13,7 +13,7 @@
  * What we'll return to browser/test utility
  * 
  */
-std::string connection::message_="HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n"
+const std::string connection::message_="HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n"
 	"<html><head><title>test</title>"
 	"</head><body><h1>Test</h1><p>This is a test!</p></body></html>";
 
@@ -25,7 +25,7 @@ std::string connection::message_="HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n
  * 
  * @return nothing
  */
-connection::connection(ba::io_service& io_service) :
+connection::connection(ba::io_service& io_service, hide_me) :
 	io_service_(io_service), socket_(io_service) {
 }
 	
@@ -42,8 +42,6 @@ void connection::run() {
 		ba::write(socket_,ba::buffer(message_),ba::transfer_all());
 		// close socket
 		socket_.close();
-		// reset pointer to themself, destroying current object
-		shared_from_this().reset();
 	} catch(std::exception& x) {
 //		std::cerr << "Exception: " << x.what() << std::endl;
 	}

--- a/test-otpc-conn.hpp
+++ b/test-otpc-conn.hpp
@@ -16,9 +16,12 @@
  * Class for handling connection in sync mode
  * 
  */
-class connection : public boost::enable_shared_from_this<connection> {
+class connection {
+	struct hide_me {};	// Instead of having to make friend boost::make_shared<connection>()
 public:
 	typedef boost::shared_ptr<connection> pointer;
+
+	connection(ba::io_service& io_service, hide_me);
 
 	/** 
 	 * Create new connection 
@@ -28,7 +31,7 @@ public:
 	 * @return pointer to newly allocated object
 	 */
 	static pointer create(ba::io_service& io_service) {
-		return pointer(new connection(io_service));
+		return boost::make_shared<connection>(io_service, hide_me());
 	}
 
 	/** 
@@ -43,12 +46,10 @@ public:
 	void run();
 	
 private:
-	connection(ba::io_service& io_service);
-	
-	ba::io_service& io_service_; /**< reference to io_service, in which work this connection */
-	ba::ip::tcp::socket socket_; /**< socket, associated with browser */
-	ba::streambuf buf;			 /**< buffer for request data */
-	static std::string message_; /**< data, that we'll return to browser */
+	ba::io_service& io_service_;	   /**< reference to io_service, in which work this connection */
+	ba::ip::tcp::socket socket_;	   /**< socket, associated with browser */
+	ba::streambuf buf;				   /**< buffer for request data */
+	const static std::string message_; /**< data, that we'll return to browser */
 };
 
 


### PR DESCRIPTION
- run multiple async acceptors in different threads
- use boost::shared_ptr<connection> as local variable (no member of the class) for each acceptor
- use boost::move to move boost::shared_ptr<> without copy and memory barrier of atomic counter
- use boost::make_shared<> to create each connection
- remove: boost::enable_shared_from_this<connection> and shared_from_this().reset(); which can only destroy a copy of the returned pointer shared_ptr<>, and can't destroying current object. The object is automatically destroyed after the completion of the function: void connection::run() - you can see it if using std::cout in destructor: ~connection()
- use a qualifier "const" for a "std::string connection::message_" that is not thread-safe on write

For completeness :)
Best regards, Alexey
