### PR TITLE
fix compile error due to boost::make_shared

### DIFF
--- a/test-otpc-conn.hpp
+++ b/test-otpc-conn.hpp
@@ -31,7 +31,7 @@ public:
 	 * @return pointer to newly allocated object
 	 */
 	static pointer create(ba::io_service& io_service) {
-		return boost::make_shared<connection>(io_service, hide_me());
+		return boost::make_shared<connection>(boost::ref(io_service), hide_me());
 	}
 
 	/** 


### PR DESCRIPTION
boost::make_shared takes a const ref. To pass a non const ref, we wrap the argument in boost::ref.
